### PR TITLE
bearerFormat not needed, we are using the standard

### DIFF
--- a/nerm/openapi.yaml
+++ b/nerm/openapi.yaml
@@ -149,4 +149,3 @@ components:
     bearerAuth:
       type: http
       scheme: bearer
-      bearerFormat: Token token=your token


### PR DESCRIPTION
We support the deafult scheme. This will ensure that curl examples in the rest of the documentation match what is in the intro.