### PR TITLE
Adding missing attributes to Template DTO objects

### DIFF
--- a/idn/beta/schemas/TemplateDto.yaml
+++ b/idn/beta/schemas/TemplateDto.yaml
@@ -18,6 +18,12 @@ properties:
       - SLACK
       - TEAMS
     example: EMAIL
+  slackTemplate:
+    type: string
+    description: Slack template
+  teamsTemplate:
+    type: string
+    description: Teams template
   locale:
     type: string
     description: The locale for the message text, a BCP 47 language tag.

--- a/idn/beta/schemas/TemplateDtoDefault.yaml
+++ b/idn/beta/schemas/TemplateDtoDefault.yaml
@@ -18,6 +18,12 @@ properties:
       - SLACK
       - TEAMS
     example: EMAIL
+  slackTemplate:
+    type: string
+    description: Slack template
+  teamsTemplate:
+    type: string
+    description: Teams template
   locale:
     type: string
     description: The locale for the message text, a BCP 47 language tag.


### PR DESCRIPTION
When using `Get-BetaNotificationTemplates` in the PowerShell SDK, it returns additional attributes `slackTemplate` and `teamsTemplate` which always seem to be null. `ConvertFrom-BetaJsonToTemplateDto` does not account for these today, so the error below is thrown.
![image](https://github.com/sailpoint-oss/api-specs/assets/14898185/dc8317cb-1dc2-4d3a-87d9-204eaf940a3e)
