### PR TITLE
WorkflowExecutionEvent.yaml issues

### DIFF
--- a/idn/v3/schemas/workflows/WorkflowExecutionEvent.yaml
+++ b/idn/v3/schemas/workflows/WorkflowExecutionEvent.yaml
@@ -1,20 +1,22 @@
 type: object
 properties:
   type:
-    description: The type of event
+    type: string
     enum:
-    - WorkflowExecutionScheduled
-    - WorkflowExecutionStarted
-    - WorkflowExecutionCompleted
-    - WorkflowExecutionFailed
-    - WorkflowTaskScheduled
-    - WorkflowTaskStarted
-    - WorkflowTaskCompleted
-    - WorkflowTaskFailed
-    - ActivityTaskScheduled
-    - ActivityTaskStarted
-    - ActivityTaskCompleted
-    - ActivityTaskFailed
+      - WorkflowExecutionScheduled
+      - WorkflowExecutionStarted
+      - WorkflowExecutionCompleted
+      - WorkflowExecutionFailed
+      - WorkflowTaskScheduled
+      - WorkflowTaskStarted
+      - WorkflowTaskCompleted
+      - WorkflowTaskFailed
+      - WorkflowTaskTimedOut
+      - ActivityTaskScheduled
+      - ActivityTaskStarted
+      - ActivityTaskCompleted
+      - ActivityTaskFailed
+    description: The type of event
     example: WorkflowTaskScheduled
   timestamp:
     type: string


### PR DESCRIPTION
type is of type string, the type was missing.
enum value WorkflowTaskTimedOut was missing.

fixes: https://github.com/sailpoint-oss/python-sdk/issues/13

