### PR TITLE
missing enum definitions that cause sdks failures

### DIFF
--- a/idn/v3/schemas/workflows/WorkflowExecution.yaml
+++ b/idn/v3/schemas/workflows/WorkflowExecution.yaml
@@ -26,6 +26,7 @@ properties:
     description: The workflow execution status
     type: string
     enum:
+    - "Executing"
     - "Completed"
     - "Failed"
     - "Canceled"

--- a/idn/v3/schemas/workflows/WorkflowExecutionEvent.yaml
+++ b/idn/v3/schemas/workflows/WorkflowExecutionEvent.yaml
@@ -1,8 +1,11 @@
 type: object
 properties:
   type:
+    type: string
     description: The type of event
     enum:
+    - TimerFired
+    - TimerStarted
     - WorkflowExecutionScheduled
     - WorkflowExecutionStarted
     - WorkflowExecutionCompleted
@@ -11,6 +14,7 @@ properties:
     - WorkflowTaskStarted
     - WorkflowTaskCompleted
     - WorkflowTaskFailed
+    - WorkflowTaskTimedOut
     - ActivityTaskScheduled
     - ActivityTaskStarted
     - ActivityTaskCompleted


### PR DESCRIPTION
the yaml is missing enum values
as the generated python code is validating responses against the data returned it is failing.